### PR TITLE
Update GH Actions to eliminate Warnings

### DIFF
--- a/.github/workflows/build-connectors.yaml
+++ b/.github/workflows/build-connectors.yaml
@@ -23,7 +23,7 @@ jobs:
       NPM_PACKAGE_FOLDER: ${{ github.workspace }}/dependencies
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: 'true'
     - name: Install Ubuntu packages
@@ -37,14 +37,14 @@ jobs:
         ruby-version: "2.6"
         bundler-cache: true
     # Node.js for wavedrom
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Setup Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '14'
     - name: Install Node.js dependencies
@@ -54,7 +54,7 @@ jobs:
         PATH=${PATH}:${BUNDLE_BIN}:$(npm bin):$(pwd) \
         make -C docs/ buildcon
     - name: Archive PDF result
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: RISC-V-Trace-Connectors
         path: docs/RISC-V-Trace-Connectors.pdf

--- a/.github/workflows/build-connectors.yaml
+++ b/.github/workflows/build-connectors.yaml
@@ -46,7 +46,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version: '16'
     - name: Install Node.js dependencies
       run: npm install ${NPM_PACKAGE_FOLDER}
     - name: Generate PDF

--- a/.github/workflows/build-control.yaml
+++ b/.github/workflows/build-control.yaml
@@ -23,7 +23,7 @@ jobs:
       NPM_PACKAGE_FOLDER: ${{ github.workspace }}/dependencies
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: 'true'
     - name: Install Ubuntu packages
@@ -37,16 +37,16 @@ jobs:
         ruby-version: "2.6"
         bundler-cache: true
     # Node.js for wavedrom
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Setup Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version: '16'
     - name: Install Node.js dependencies
       run: npm install ${NPM_PACKAGE_FOLDER}
     - name: Generate PDF
@@ -54,7 +54,7 @@ jobs:
         PATH=${PATH}:${BUNDLE_BIN}:$(npm bin):$(pwd) \
         make -C docs/ buildctrl
     - name: Archive PDF result
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: RISC-V-Trace-Control-Interface
         path: docs/RISC-V-Trace-Control-Interface.pdf

--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -23,7 +23,7 @@ jobs:
       NPM_PACKAGE_FOLDER: ${{ github.workspace }}/dependencies
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: 'true'
     - name: Install Ubuntu packages
@@ -37,16 +37,16 @@ jobs:
         ruby-version: "2.6"
         bundler-cache: true
     # Node.js for wavedrom
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Setup Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version: '16'
     - name: Install Node.js dependencies
       run: npm install ${NPM_PACKAGE_FOLDER}
     - name: Generate PDF
@@ -54,7 +54,7 @@ jobs:
         PATH=${PATH}:${BUNDLE_BIN}:$(npm bin):$(pwd) \
         make -C docs/ buildall
     - name: Archive PDF result
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: RISC-V-Trace-Control-Interface.pdf
         path: docs/RISC-V-Trace-Control-Interface.pdf


### PR DESCRIPTION
These commits migrate GH Actions to Node 16 and update Action versions to levels which avoid the deprecated interfaces.