### PR TITLE
Table formatting changes

### DIFF
--- a/docs/RISC-V-Trace-Control-Interface.adoc
+++ b/docs/RISC-V-Trace-Control-Interface.adoc
@@ -129,7 +129,7 @@ The Trace Control interface consists of a set of 32-bit registers. The control i
 This specification defines the following trace components:
 
 //[cols="15%,15%,10%,~",options="header",]
-[cols="3,6,4,10"]
+[cols="4,6,4,10"]
 |===
 |*Component Name* |*Component Type (value=symbol)*|*Base Address (symbol)* |*Description*
 |Trace Encoder |0x1=TRCOMP_ENCODER|trBaseEncoder|Accepts execution information from a core (via Trace Ingress Port) and generates a stream of trace messages/packets.

--- a/docs/RISC-V-Trace-Control-Interface.adoc
+++ b/docs/RISC-V-Trace-Control-Interface.adoc
@@ -129,7 +129,7 @@ The Trace Control interface consists of a set of 32-bit registers. The control i
 This specification defines the following trace components:
 
 //[cols="15%,15%,10%,~",options="header",]
-[cols="1,2,3,10"]
+[cols="3,4,3,10"]
 |===
 |*Component Name* |*Component Type (value=symbol)*|*Base Address (symbol)* |*Description*
 |Trace Encoder |0x1=TRCOMP_ENCODER|trBaseEncoder|Accepts execution information from a core (via Trace Ingress Port) and generates a stream of trace messages/packets.

--- a/docs/RISC-V-Trace-Control-Interface.adoc
+++ b/docs/RISC-V-Trace-Control-Interface.adoc
@@ -129,7 +129,7 @@ The Trace Control interface consists of a set of 32-bit registers. The control i
 This specification defines the following trace components:
 
 //[cols="15%,15%,10%,~",options="header",]
-[cols="3,4,3,10"]
+[cols="3,5,4,10"]
 |===
 |*Component Name* |*Component Type (value=symbol)*|*Base Address (symbol)* |*Description*
 |Trace Encoder |0x1=TRCOMP_ENCODER|trBaseEncoder|Accepts execution information from a core (via Trace Ingress Port) and generates a stream of trace messages/packets.

--- a/docs/RISC-V-Trace-Control-Interface.adoc
+++ b/docs/RISC-V-Trace-Control-Interface.adoc
@@ -129,7 +129,7 @@ The Trace Control interface consists of a set of 32-bit registers. The control i
 This specification defines the following trace components:
 
 //[cols="15%,15%,10%,~",options="header",]
-[%autowidth,cols="1,2,3,10"]
+[cols="1,2,3,10"]
 |===
 |*Component Name* |*Component Type (value=symbol)*|*Base Address (symbol)* |*Description*
 |Trace Encoder |0x1=TRCOMP_ENCODER|trBaseEncoder|Accepts execution information from a core (via Trace Ingress Port) and generates a stream of trace messages/packets.

--- a/docs/RISC-V-Trace-Control-Interface.adoc
+++ b/docs/RISC-V-Trace-Control-Interface.adoc
@@ -163,7 +163,8 @@ NOTE: Additional control path(s) may also be implemented, such as extra JTAG reg
 
 Each  block of 32-bit registers (for each component) has the following layout:
 
-[cols="15%,20%,10%,~",options="header",]
+//[cols="15%,20%,10%,~",options="header",]
+[cols="~,~,~,~"]
 |===
 |*Address Offset* |*Register Name* |*Compliance* |*Description*
 |0x000 |tr??Control |Required |Main control register for trace component ??

--- a/docs/RISC-V-Trace-Control-Interface.adoc
+++ b/docs/RISC-V-Trace-Control-Interface.adoc
@@ -129,7 +129,7 @@ The Trace Control interface consists of a set of 32-bit registers. The control i
 This specification defines the following trace components:
 
 //[cols="15%,15%,10%,~",options="header",]
-[%autowidth,cols="1,1,2,12"]
+[%autowidth,cols="1,2,3,10"]
 |===
 |*Component Name* |*Component Type (value=symbol)*|*Base Address (symbol)* |*Description*
 |Trace Encoder |0x1=TRCOMP_ENCODER|trBaseEncoder|Accepts execution information from a core (via Trace Ingress Port) and generates a stream of trace messages/packets.

--- a/docs/RISC-V-Trace-Control-Interface.adoc
+++ b/docs/RISC-V-Trace-Control-Interface.adoc
@@ -128,7 +128,8 @@ The Trace Control interface consists of a set of 32-bit registers. The control i
 
 This specification defines the following trace components:
 
-[cols="15%,15%,10%,~",options="header",]
+//[cols="15%,15%,10%,~",options="header",]
+[%autowidth]
 |===
 |*Component Name* |*Component Type (value=symbol)*|*Base Address (symbol)* |*Description*
 |Trace Encoder |0x1=TRCOMP_ENCODER|trBaseEncoder|Accepts execution information from a core (via Trace Ingress Port) and generates a stream of trace messages/packets.

--- a/docs/RISC-V-Trace-Control-Interface.adoc
+++ b/docs/RISC-V-Trace-Control-Interface.adoc
@@ -129,7 +129,7 @@ The Trace Control interface consists of a set of 32-bit registers. The control i
 This specification defines the following trace components:
 
 //[cols="15%,15%,10%,~",options="header",]
-[cols="3,5,4,10"]
+[cols="3,6,4,10"]
 |===
 |*Component Name* |*Component Type (value=symbol)*|*Base Address (symbol)* |*Description*
 |Trace Encoder |0x1=TRCOMP_ENCODER|trBaseEncoder|Accepts execution information from a core (via Trace Ingress Port) and generates a stream of trace messages/packets.

--- a/docs/RISC-V-Trace-Control-Interface.adoc
+++ b/docs/RISC-V-Trace-Control-Interface.adoc
@@ -129,7 +129,7 @@ The Trace Control interface consists of a set of 32-bit registers. The control i
 This specification defines the following trace components:
 
 //[cols="15%,15%,10%,~",options="header",]
-[%autowidth]
+[%autowidth,cols="1,1,2,12"]
 |===
 |*Component Name* |*Component Type (value=symbol)*|*Base Address (symbol)* |*Description*
 |Trace Encoder |0x1=TRCOMP_ENCODER|trBaseEncoder|Accepts execution information from a core (via Trace Ingress Port) and generates a stream of trace messages/packets.

--- a/docs/RISC-V-Trace-Control-Interface.adoc
+++ b/docs/RISC-V-Trace-Control-Interface.adoc
@@ -129,7 +129,7 @@ The Trace Control interface consists of a set of 32-bit registers. The control i
 This specification defines the following trace components:
 
 //[cols="15%,15%,10%,~",options="header",]
-[cols="4,6,4,10"]
+[cols="4,7,4,10"]
 |===
 |*Component Name* |*Component Type (value=symbol)*|*Base Address (symbol)* |*Description*
 |Trace Encoder |0x1=TRCOMP_ENCODER|trBaseEncoder|Accepts execution information from a core (via Trace Ingress Port) and generates a stream of trace messages/packets.


### PR DESCRIPTION
Added two different ways of formatting tables to make them more legible in the generated PDFs.  First way is to play with the col attributes until you find acceptable widths for the content.  Second way (and easiest) is to use the ~ on all of the columns.  See 3.1 Trace Components table for the first method and 3.3 Trace Component Register Map for the second method.  I think using the second method makes sense as the first is subject to error more easily.