### PR TITLE
Add smstrc changes

### DIFF
--- a/docs/RISC-V-Trace-Control-Interface.adoc
+++ b/docs/RISC-V-Trace-Control-Interface.adoc
@@ -103,9 +103,9 @@ This specification allows a wide range of implementations including low-gate-cou
 
 *RW* - Denotes read-write bit/field - value being read may not be the same as what was written as some fields may change their values because of other reasons.
 
-*RW1C* - Denotes bit/field, which can be read but you must write 1 to clear it (writing 0 will be ignored). It is used for sticky status bits to assure that these are cleared by deliberate action (write 1). 
+*RW1C* - Denotes bit/field, which can be read but you must write 1 to clear it (writing 0 will be ignored). It is used for sticky status bits to assure that these are cleared by deliberate action (write 1).
 
-*WARL* - Denotes Write any, read legal bit/field/register. If a non-legal value is written, the written value is converted to a value that is supported. That value should deterministically depend on the illegal written value and the architectural state of the trace sub-system. 
+*WARL* - Denotes Write any, read legal bit/field/register. If a non-legal value is written, the written value is converted to a value that is supported. That value should deterministically depend on the illegal written value and the architectural state of the trace sub-system.
 
 *W1* - Denotes write-only bit, which performs an action when 1 is written to it.
 
@@ -126,7 +126,7 @@ This specification allows a wide range of implementations including low-gate-cou
 There are two standard RISC-V trace protocols which will utilize this *RISC-V Trace Control Interface*:
 
 [#N-Trace Specification]
-* *RISC-V N-Trace (Nexus-based Trace) Specification* 
+* *RISC-V N-Trace (Nexus-based Trace) Specification*
 ** Version 1.0 to be ratified together with this specification.
 
 [#E-Trace Specification]
@@ -255,7 +255,7 @@ Different components must be connected via internal busses and/or FIFO buffers. 
 NOTE: Sending RISC-V trace to Arm CoreSight infrastructure is allowed (via ATB Bridge), but this specification does not specify how to transport trace data from other Arm CoreSight components in the system using RISC-V Trace sub-system.
 One of possible ways of doing so would be to create a custom trace component, configure it to encapsulate it as custom N-Trace trace messages and connect it as input to one of trace funnels.
 
-==== Example Component Connection Diagrams 
+==== Example Component Connection Diagrams
 
 ////
 This comment is taken AS-IS from iommu_intro.adoc file
@@ -282,7 +282,7 @@ Other potential unicode characters might be found in the following links:
 ....
 +----------------+
 | Single Hart    |
-|         +----------+    +---------+     +------------+ 
+|         +----------+    +---------+     +------------+
 |         |  Trace   |    |  Trace  |     | Trace Sink |
 |         | Ingress =====>| Encoder |---->|    or      |
 |         |  Port    |    |         |     | ATB Bridge |
@@ -302,7 +302,7 @@ Other potential unicode characters might be found in the following links:
 |  Port     |   |         |   |
 +-----------+   +---------+   |
                               |
-+-----------+   +---------+   |   +--------+     +-------------+ 
++-----------+   +---------+   |   +--------+     +-------------+
 | Hart with |   |  Trace  |   +-->| Trace  |     | Trace Sink  |
 | Ingress   |==>| Encoder |------>| Funnel |---->|    or       |
 |  Port     |   |         |   +-->|        |     | ATB Bridge  |
@@ -316,21 +316,21 @@ Other potential unicode characters might be found in the following links:
 ....
 
 [[fig:trace-topo-clusters]]
-.Multi-cluster trace: two three-hart clusters with top-level Funnel and Sink/Bridge  
+.Multi-cluster trace: two three-hart clusters with top-level Funnel and Sink/Bridge
 ["ditaa",shadows=false, separation=false, fontsize: 12]
 ....
 +-------------------------+
 | 3 Harts with 3 Encoders |
 |   and local Funnel      |---+
-|       (see above)       |   | 
+|       (see above)       |   |
 +-------------------------+   |
-                              |   +--------+     +-------------+ 
+                              |   +--------+     +-------------+
                               +-->| Trace  |     | Trace Sink  |
                                   | Funnel |---->|    or       |
                               +-->| (top)  |     | ATB Bridge  |
                               |   +--------+     +-------------+
 +-------------------------+   |
-| 3 Harts with 3 Encoders |   | 
+| 3 Harts with 3 Encoders |   |
 |   and local Funnel      |---+
 |       (see above)       |
 +-------------------------+
@@ -343,20 +343,20 @@ Other potential unicode characters might be found in the following links:
 +-------------------------+
 | 3 Harts with 3 Encoders |
 |     and local Funnel    |---+
-|       (see above)       |   | 
+|       (see above)       |   |
 +-------------------------+   |
                               |
-+-----------+   +---------+   |   +--------+     +-------------+ 
++-----------+   +---------+   |   +--------+     +-------------+
 | Hart #4   |   |  Trace  |   +-->| Trace  |     | Trace Sink  |
 |           |==>| Encoder |------>| Funnel |---->|    or       |
 |           |   |   #4    |---+   | (top)  |     | ATB Bridge  |
 +-----------+   +---------+   |   +--------+     +-------------+
                               |
                               v
-                      +----------------+ 
+                      +----------------+
                       | Trace RAM Sink |
                       | (in SRAM mode) |
-                      +----------------+ 
+                      +----------------+
 ....
 
 NOTE: Trace data from *Trace Encoder #4* may be combined with trace from other 3 Trace Encoders. But it may be also sent to dedicated *Trace RAM Sink* - in such a case corresponding input to *Trace Funnel (top)* should be disabled.
@@ -391,7 +391,7 @@ Each  block of 32-bit registers (for each component) has the following layout:
 |0xE00 - 0xFFF |--|Optional |Registers reserved for implementation/vendor specific details. May allow identification of components on a system bus.
 |===
 
-WARNING: Each component has a `tr??Active` bit in the `tr??Control` register. Accesses to other registers are unspecified when the `tr??Active` bit is 0. 
+WARNING: Each component has a `tr??Active` bit in the `tr??Control` register. Accesses to other registers are unspecified when the `tr??Active` bit is 0.
 
 Each trace component has a `tr??Impl` register (at address offset 0x4) allowing trace component version and trace component type to be identified. This register allows debug tools to confirm the component type and potentially adjust tool behavior by looking at component versions.
 
@@ -506,7 +506,7 @@ Each component has a `tr??Impl` register, which includes two 4-bit `tr??VerMinor
 * Value 0 as `tr??VerMajor` is NOT allowed (due to compatibility reasons).
 * Different components may report different versions (as some components may be updated more often than others).
 * The major version `tr??VerMajor` field is incremented when the modification breaks backward compatibility.
-* The minor version `tr??VerMinor` field  is incremented when the modification maintains backward compatibility (for example adding a new field) - for that reason software should always write 0 to reserved bits in registers. 
+* The minor version `tr??VerMinor` field  is incremented when the modification maintains backward compatibility (for example adding a new field) - for that reason software should always write 0 to reserved bits in registers.
 * Version 15.x is reserved for non-compatible version encoding.
 * Version n.15 should be used as experimental (in development) implementation.
 
@@ -556,7 +556,7 @@ NOTE: When non-supported mode (different than 0) is set, it cannot revert to 0 b
 |WARL|<<Undef,Undef>>
 |8:7 |--|Reserved|--|0
 |9 |trTeContext |Enable sending trace messages/fields with scontext/mcontext values and/or privilege levels. |WARL|<<Undef,Undef>>
-|10 |--|Reserved|--|0
+|10 |trTeDisSelfHosted |When set, the hart behaves as though self-hosted trace ISA extensions Smstrc*/Ssstrc* are not implemented. |WARL|<<Undef,Undef>>
 |11  |trTeInstTrigEnable |*1:* Allows `trTeInstTracing` to be set or cleared by Trace-on
 and Trace-off signals generated by the corresponding trigger module.|WARL|<<Undef,Undef>>
 |12  |trTeInstStallOrOverflow |Set to 1 by hardware when trace buffer overflow (also known as trace lost) occurs, or when the TE requests a hart stall. Clears to 0 at TE reset or when the trace is enabled (`trTeEnable` set to 1). Write 1 to clear.|RW1C|<<Undef,Undef>>
@@ -569,7 +569,7 @@ and Trace-off signals generated by the corresponding trigger module.|WARL|<<Unde
 |15 |trTeInhibitSrc |
 *0:* Messages/packets generated by the trace encoder include a message source field if the
  source width held in `trTeSrcBits` is not 0. +
-*1:* Disable inclusion of source field in trace messages/packets. 
+*1:* Disable inclusion of source field in trace messages/packets.
 |WARL|<<Undef,Undef>>
 
 |17:16 |trTeInstSyncMode |Select the periodic instruction trace synchronization message/packet generation mechanism. At least one non-zero mechanism must be implemented. +
@@ -594,6 +594,9 @@ Trace recording/protocol format: +
 |===
 
 NOTE: Writing to this register while trace is enabled may unintentionally change a value of `trTeInstTracing` bit because that bit may dynamically change by triggers.
+
+NOTE: The trTeDisSelfHosted bit provides a means for an external debugger to reserve the TE for itself, by hiding the availability of self-hosted trace from software running on the hart.  If set from boot, it is reasonable to expect that software will never attempt to use self-hosted trace.  Otherwise the debugger may need to handle exceptions that result from software attempts to access self-hosted trace CSRs.  The debugger could use an etrigger to intercept the exceptions, at which point it could emulate the access or clear trTeDisSelfHosted and reexecute the write, among other options.
+
 
 .*Register: trTeImpl: Trace Encoder Implementation Register (trBaseEncoder+0x004)*
 [cols="6%,24%,~,7%,7%",options="header"]
@@ -692,7 +695,7 @@ Determine which filters defined in <<Trace Encoder Filter Registers, Trace Encod
 <<<
 === Timestamp Unit
 
-Timestamp Unit is an optional sub-component present in either Trace Encoder or Trace Funnel. An implementation may choose from several modes of timestamps: 
+Timestamp Unit is an optional sub-component present in either Trace Encoder or Trace Funnel. An implementation may choose from several modes of timestamps:
 
 * *Internal System* - fixed clock in a system (such as bus clock) is used to increment the timestamp counter (for both Trace Encoders and Trace Funnels)
 * *Internal Core* - core clock is used to increment the timestamp counter (only for Trace Encoders)
@@ -724,7 +727,7 @@ See <<Reset and Discovery,Reset and Discovery>> chapter for more details.|WARL|S
 Write 1 to reset the timestamp counter.|W1|--
 |3 |trTsRunInDebug |*Internal Core* timestamp only. +
 *1:* counter runs when hart is halted (in debug mode), +
-*0:* stopped 
+*0:* stopped
 |WARL|<<Undef,Undef>>
 |6:4 |trTsMode a|
 Mode used by Timestamp unit: +
@@ -778,13 +781,13 @@ When `trTeInstTrigEnable` = 1 it will start instruction tracing (`trTeInstTracin
 When `trTeDataTrigEnable` = 1 it will start data tracing (`trTeDataTracing` -> 1).
 |3 |*Trace-off action* +
 When `trTeInstTrigEnable` = 1 it will stop instruction tracing (`trTeInstTracing` -> 0). +
-When `trTeDataTrigEnable` = 1 it will stop data tracing (`trTeDataTracing` -> 0). 
+When `trTeDataTrigEnable` = 1 it will stop data tracing (`trTeDataTracing` -> 0).
 |4 |*Trace-notify action* +
 If tracing is active (`trTeInstTracing` = 1), then the encoder generates a packet with the current PC and, if enabled, a timestamp.
 |5 |*Vendor-specific trace action* (optional)
 |===
 
-If there are vendor-specific features that require control, the `trTeTrigDbgControl` register is used. 
+If there are vendor-specific features that require control, the `trTeTrigDbgControl` register is used.
 
 .*Register: trTeTrigDbgControl: Debug Trigger Control Register (trBaseEncoder+0x050)*
 [cols="6%,24%,~,7%,7%",options="header"]
@@ -829,7 +832,7 @@ If tracing is active (`trTeInstTracing` = 1), then the encoder generates a packe
 Bitmap to select which event(s) cause external trigger #0 output to fire. If external trigger output #0 does not exist, then all bits are fixed at 0. Bits 2 and 3 may be fixed at 0 if the corresponding feature is not implemented. +
 *Bit 0:* +
 Start trace transition (`trTeInstTracing` 0 -> 1) will fire the trigger. +
-*Bit 1:* + 
+*Bit 1:* +
 Stop trace transition (`trTeInstTracing` 1 -> 0) will fire the trigger. +
 *Bit 2-3:* +
 Vendor-specific event (optional)
@@ -886,45 +889,45 @@ NOTE: Filter and comparator registers refer to values of some signals (as *priv*
 [cols="6%,24%,~,7%,7%",options="header"]
 |===
 |*Bit* |*Field* |*Description* |*RW* |*Reset*
-|0     |trTeFilterEnable | Overall filter enable for filter #__i__|WARL|<<Undef,Undef>> 
-|1     |trTeFilterMatchPrivilege | 
+|0     |trTeFilterEnable | Overall filter enable for filter #__i__|WARL|<<Undef,Undef>>
+|1     |trTeFilterMatchPrivilege |
 When set, match privilege levels specified by `trTeFilterMatchChoicePrivilege` field for filter #__i__.
 |WARL|<<Undef,Undef>>
-|2     |trTeFilterMatchEcause | 
+|2     |trTeFilterMatchEcause |
 When set, start matching from exception cause codes specified by `trTeFilterMatchChoiceEcause` field for filter #__i__, and
 stop matching upon return from the 1st matching exception.
 |WARL|<<Undef,Undef>>
-|3     |trTeFilterMatchInterrupt | 
-When set, start matching from either an interrupt or exception as specified by  
+|3     |trTeFilterMatchInterrupt |
+When set, start matching from either an interrupt or exception as specified by
 `trTeFilterMatchValueInterrupt` field for filter #__i__, and stop matching upon return from the 1st matching trap.
 |WARL|<<Undef,Undef>>
-|4     |trTeFilterMatchComp1 | 
+|4     |trTeFilterMatchComp1 |
 When set, the output of the comparator selected by `trTeFilterComp1` must be true for the filter to match.
 |WARL|<<Undef,Undef>>
 |7:5   |trTeFilterComp1 |
 Specifies the comparator unit to use for the 1st comparison.
 |WARL|<<Undef,Undef>>
-|8     |trTeFilterMatchComp2 | 
+|8     |trTeFilterMatchComp2 |
 When set, the output of the comparator selected by `trTeFilterComp2` must be true for the filter to match.
 |WARL|<<Undef,Undef>>
 |11:9  |trTeFilterComp2 |
 Specifies the comparator unit to use for the 2nd comparison.
 |WARL|<<Undef,Undef>>
-|12    |trTeFilterMatchComp3 | 
+|12    |trTeFilterMatchComp3 |
 When set, the output of the comparator selected by `trTeFilterComp3` must be true for the filter to match.
 |WARL|<<Undef,Undef>>
 |15:13 |trTeFilterComp3 |
 Specifies the comparator unit to use for the 3rd comparison.
 |WARL|<<Undef,Undef>>
-|16    |trTeFilterMatchImpdef | 
-When set, match *impdef* values as specified by `trTeFilterMatchValueImpdef` and 
+|16    |trTeFilterMatchImpdef |
+When set, match *impdef* values as specified by `trTeFilterMatchValueImpdef` and
 `trTeFilterMatchMaskImpdef` fields for filter #__i__.
 |WARL|<<Undef,Undef>>
 |23:17 |--|Reserved|--|0
-|24    |trTeFilterMatchDtype | 
+|24    |trTeFilterMatchDtype |
 When set, match *dtype* values as specified by `trTeFilterMatchChoiceDtype` field for filter #__i__.
 |WARL|<<Undef,Undef>>
-|25    |trTeFilterMatchDsize | 
+|25    |trTeFilterMatchDsize |
 When set, match *dsize* values as specified by `trTeFilterMatchChoiceDsize` field for filter #__i__.
 |WARL|<<Undef,Undef>>
 |31:26 |--|Reserved|--|0
@@ -936,14 +939,14 @@ NOTE: Handling of `trTeFilterMatchEcause` and `trTeFilterMatchInterrupt` should 
 [cols="6%,30%,~,7%,7%",options="header"]
 |===
 |*Bit* |*Field* |*Description* |*RW* |*Reset*
-|7:0   |trTeFilterMatchChoicePrivilege | 
+|7:0   |trTeFilterMatchChoicePrivilege |
 When `trTeFilterMatchPrivilege` field for filter #__i__ is set, match all privilege
 levels for which the corresponding bit is set. For example, if bit N is 1, then match if the *priv* value at ingress port is N. Setting several bits allow matching several privileges.
-|WARL|<<Undef,Undef>> 
+|WARL|<<Undef,Undef>>
 |8     |trTeFilterMatchValueInterrupt |
 When `trTeFilterMatchInterrupt` field for filter #__i__ is set, match *itype* of 2 or 1 depending on whether this bit is 1 or 0
 respectively.
-|WARL|<<Undef,Undef>> 
+|WARL|<<Undef,Undef>>
 |31:9 |--|Reserved|--|0
 |===
 
@@ -952,9 +955,9 @@ respectively.
 [cols="6%,30%,~,7%,7%",options="header"]
 |===
 |*Bit* |*Field* |*Description* |*RW* |*Reset*
-|31:0   |trTeFilterMatchChoiceEcauseLow | 
+|31:0   |trTeFilterMatchChoiceEcauseLow |
 When `trTeFilterMatchEcause` field for filter #__i__ is set, match all excepion causes for which the corresponding bit is set. If bit N is 1, then match if the *ecause* is N.
-|WARL|<<Undef,Undef>> 
+|WARL|<<Undef,Undef>>
 |===
 
 .*Register: trTeFilter__i__MatchEcauseHigh : Filter _i_ Ecause Match Control (high) Register (trBaseEncoder+0x40C + 0x20__i__)*
@@ -962,43 +965,43 @@ When `trTeFilterMatchEcause` field for filter #__i__ is set, match all excepion 
 |===
 |*Bit* |*Field* |*Description* |*RW* |*Reset*
 |31:0   |trTeFilterMatchChoiceEcauseHigh | Stores bits 63:32 to allow matching of higher *ecause* codes. If bit N is 1, then match if the *ecause* is N+32.
-|WARL|<<Undef,Undef>> 
+|WARL|<<Undef,Undef>>
 |===
 
 .*Register: trTeFilter__i__MatchValueImpdef : Filter _i_ Impdef Match Value Register (trBaseEncoder+0x410 + 0x20__i__)*
 [cols="6%,24%,~,7%,7%",options="header"]
 |===
 |*Bit* |*Field* |*Description* |*RW* |*Reset*
-|31:0   |trTeFilterMatchValueImpdef | 
+|31:0   |trTeFilterMatchValueImpdef |
 When `trTeFilterMatchimpdef` field for filter #__i__ is set, match if
 (*impdef* & `trTeFilterMatchMaskImpdef`) ==
 (`trTeFilterMatchValueImpdef` & `trTeFilterMatchMaskImpdef`).
-|WARL|<<Undef,Undef>> 
+|WARL|<<Undef,Undef>>
 |===
 
 .*Register: trTeFilter__i__MatchMaskImpdef : Filter _i_ Impdef Match Mask Register (trBaseEncoder+0x414 + 0x20__i__)*
 [cols="6%,24%,~,7%,7%",options="header"]
 |===
 |*Bit* |*Field* |*Description* |*RW* |*Reset*
-|31:0   |trTeFilterMatchMaskImpdef | 
+|31:0   |trTeFilterMatchMaskImpdef |
 When `trTeFilterMatchimpdef` field for filter #__i__ is set, match if
 (*impdef* & `trTeFilterMatchMaskImpdef`) ==
 (`trTeFilterMatchValueImpdef` & `trTeFilterMatchMaskImpdef`).
-|WARL|<<Undef,Undef>> 
+|WARL|<<Undef,Undef>>
 |===
 
 .*Register: trTeFilter__i__MatchData : Filter _i_ Data Match Control Register (trBaseEncoder+0x418 + 0x20__i__)*
 [cols="6%,24%,~,7%,7%",options="header"]
 |===
 |*Bit* |*Field* |*Description* |*RW* |*Reset*
-|15:0   |trTeFilterMatchChoiceDtype | 
+|15:0   |trTeFilterMatchChoiceDtype |
 When `trTeFilterMatchDtype` field for filter #__i__ is set, match all data access types
 for which the corresponding bit is set. For example, if bit N is 1, then match if the *dtype* value is N.
-|WARL|<<Undef,Undef>> 
+|WARL|<<Undef,Undef>>
 |23:16  |trTeFilterMatchChoiceDsize |
 When `trTeFilterMatchDsize` field for filter #__i__ is set, match all data access sizes
 for which the corresponding bit is set. For example, if bit N is 1, then match if the *dsize* value is N.
-|WARL|<<Undef,Undef>> 
+|WARL|<<Undef,Undef>>
 |31:24 |--|Reserved|--|0
 |===
 
@@ -1007,13 +1010,13 @@ for which the corresponding bit is set. For example, if bit N is 1, then match i
 [cols="6%,24%,~,7%,7%",options="header"]
 |===
 |*Bit* |*Field* |*Description* |*RW* |*Reset*
-|1:0   |trTeCompPInput | 
+|1:0   |trTeCompPInput |
 Determines which input to compare against the primary comparator. +
 *0:* *iaddr* +
 *1:* *context* +
 *2:* *tval* +
 *3:* *daddr*
-|WARL|<<Undef,Undef>> 
+|WARL|<<Undef,Undef>>
 |3:2   |trTeCompSInput | Determines which input to compare against the secondary comparator.  Same encoding as `trTeCompPInput`. |WARL|<<Undef,Undef>>
 |6:4   |trTeCompPFunction |
 Selects the primary comparator function.  Primary result is true if input selected via `trTeCompPInput` is: +
@@ -1046,13 +1049,13 @@ Selects the match condition used to assert the overall comparator output +
 *2:* Either primary or secondary result does not match: !(P && S) +
 *3:* Set when primary result is true and continue to assert until instruction after secondary result is true
 |WARL|<<Undef,Undef>>
-|14   |trTeCompPNotify | 
+|14   |trTeCompPNotify |
 Generate a trace packet explicitly reporting the address
 of the final instruction in a block that causes a
 primary match. This is also known as a watchpoint.
 Requires `trTeCompPInput` to be 0, and has no effect otherwise.
 |WARL|<<Undef,Undef>>
-|15   |trTeCompSNotify | 
+|15   |trTeCompSNotify |
 Generate a trace packet explicitly reporting the address
 of the final instruction in a block that causes a
 secondary match. This is also known as a watchpoint.
@@ -1068,36 +1071,36 @@ IMPORTANT: Comparisions are performed as unsigned numbers. Only bits from an inp
 [cols="6%,24%,~,7%,7%",options="header"]
 |===
 |*Bit* |*Field* |*Description* |*RW* |*Reset*
-|31:0   |trTeCompPMatchLow | 
+|31:0   |trTeCompPMatchLow |
 The match value for the primary comparator (bits 31:0).
-|WARL|<<Undef,Undef>> 
+|WARL|<<Undef,Undef>>
 |===
 
 .*Register: trTeComp__j__PMatchHigh : Comparator _j_ Primary match (high) Register (trBaseEncoder+0x614 + 0x20__j__)*
 [cols="6%,24%,~,7%,7%",options="header"]
 |===
 |*Bit* |*Field* |*Description* |*RW* |*Reset*
-|31:0   |trTeCompPMatchHigh | 
+|31:0   |trTeCompPMatchHigh |
 The match value for the primary comparator (bits 63:32).
-|WARL|<<Undef,Undef>> 
+|WARL|<<Undef,Undef>>
 |===
 
 .*Register: trTeComp__j__SMatchLow : Comparator _j_ Secondary match (low) Register (trBaseEncoder+0x618 + 0x20__j__)*
 [cols="6%,24%,~,7%,7%",options="header"]
 |===
 |*Bit* |*Field* |*Description* |*RW* |*Reset*
-|31:0   |trTeCompSMatchLow | 
+|31:0   |trTeCompSMatchLow |
 The match value for the secondary comparator (bits 31:0).
-|WARL|<<Undef,Undef>> 
+|WARL|<<Undef,Undef>>
 |===
 
 .*Register: trTeComp__j__SMatchHigh : Comparator _j_ Secondary match (high) Register (trBaseEncoder+0x61C + 0x20__j__)*
 [cols="6%,24%,~,7%,7%",options="header"]
 |===
 |*Bit* |*Field* |*Description* |*RW* |*Reset*
-|31:0   |trTeCompSMatchHigh | 
+|31:0   |trTeCompSMatchHigh |
 The match value for the secondary comparator (bits 63:32).
-|WARL|<<Undef,Undef>> 
+|WARL|<<Undef,Undef>>
 |===
 
 == Trace RAM Sink
@@ -1161,7 +1164,7 @@ NOTE: Single RAM Sink may support both SRAM and SMEM modes, but not both may be 
 |31:2 |trRamStartLow |Byte address of start of trace sink circular buffer. It is always aligned on at least a 32-bit/4-byte boundary. An SRAM sink will usually have `trRamStartLow` fixed at 0. |WARL|<<Undef,Undef>> or fixed to 0
 |===
 
-For a bus with an address larger than 32-bit, corresponding `High` registers define the MSB part of such a larger address. 
+For a bus with an address larger than 32-bit, corresponding `High` registers define the MSB part of such a larger address.
 
 .*Register: trRamStartHigh: Trace RAM Sink Start High Bits Register (trBaseRamSink+0x014)*
 [cols="6%,24%,~,7%,7%",options="header"]
@@ -1238,7 +1241,7 @@ The table below shows typical Trace RAM Sink configurations. Implementing other 
 
 NOTE: Value `A` means alignment which depends on memory access width. If we have memory access width of 32-bits, A=4 and value of `trRamLimit` register should be 0x...FC. Some implementations may impose bigger alignment of trace data (to allow more efficient transfer rates) for SMEM mode. For SRAM mode `A` must be 4 as access to trace via `trRamData` is always 32-bits wide.
 
-=== Accessing and Detecting RAM Sink Registers 
+=== Accessing and Detecting RAM Sink Registers
 
 Trace tool should start interacting with Trace RAM Sink by releasing RAM Sink from reset by setting `trRamActive` = 1 and waiting for this bit to be set. After that it should verify `trRamEmpty` = 1, read `trRamImpl` and verify `trRamCompType` and `trRamVer??` fields. Values of `trRamHasSRAM/SMEM` fields will provide main types of RAM Sink being implemented.
 
@@ -1253,7 +1256,7 @@ Some implementations may provide different limits for different start addresses,
 
 Not every value may be settable in `trRamStart/Limit` registers. Value written may be trimmed (for example aligned on a particular 2^N boundary) and a trace tool should verify values being written. In case accepted values are different from what was provided by the user, a message should be printed which may allow the user to adjust (possbly suboptimal) settings.
 
-Registers `trRamStart??` and `trRamLimit??` are usually set at the beginning of a debug/trace session and never changed. 
+Registers `trRamStart??` and `trRamLimit??` are usually set at the beginning of a debug/trace session and never changed.
 
 IMPORTANT: In SMEM mode (`trRamMode` = 1) trace tool should never set `trRamStart??` and `trRamLimit??` registers outside of range provided by the user as otherwise raw trace being written to memory may corrupt running code and/or data or stack. This type of errors may be very difficult to diagnose as in complex system code (or data) being overwritten by trace may be used way, way later after actual corruption was made.
 
@@ -1342,9 +1345,9 @@ down, and other register locations may be inaccessible. Hardware may take an arb
 Details should be defined in the specification of each trace protocol.
 |WARL|<<Undef,Undef>>
 |15 |--|Reserved|--|0
-|31:16 |trPibDivider |Timebase selection for the PIB module. The input clock is divided by `trPibDivider` + 1. PIB data is sent at either this divided rate or 1/2 of this rate, depending on `trPibMode`. Width is implementation dependent. 
-After the PIB reset value of this field should be set to safe (not too fast clock) setting for a particular SoC. Trace tools may set smaller values to utilize higher bandwidth. 
-|WARL|<<Undef,Undef>> 
+|31:16 |trPibDivider |Timebase selection for the PIB module. The input clock is divided by `trPibDivider` + 1. PIB data is sent at either this divided rate or 1/2 of this rate, depending on `trPibMode`. Width is implementation dependent.
+After the PIB reset value of this field should be set to safe (not too fast clock) setting for a particular SoC. Trace tools may set smaller values to utilize higher bandwidth.
+|WARL|<<Undef,Undef>>
 |===
 
 <<<
@@ -1392,14 +1395,14 @@ Since the PIB supports many different modes, it is necessary to follow a particu
 * Trace messages/packets are considered as sequences of bytes and are always transmitted with least significant bits/bytes first.
 * In 16-bit mode (`trPibMode` == 12) the byte transmitted on bits #0-#7 is considered first and most significant bits#8-#15 are transmitting second byte.
 * Idle sequences (no message/packet to be sent) are transmitted between messages.
-** Idle sequence depends on trace protocol and must allow detection of the start of first byte of message/packet following the idle sequence. 
+** Idle sequence depends on trace protocol and must allow detection of the start of first byte of message/packet following the idle sequence.
 ** Idle sequences may be different and should be defined by trace protocols.
 
 === PIB Parallel Protocol
 
 Traditionally, off-chip trace has used this protocol. There are several parallel data signals (TRC_DATA0..15) and one continuously-running trace clock (TRC_CLK). The data rate of parallel signals can be much higher than either of the serial-wire protocols.
 
-This protocol is oriented to send full, variable length trace messages/packets rather than fixed-width trace words. 
+This protocol is oriented to send full, variable length trace messages/packets rather than fixed-width trace words.
 
 When a message start is detected, this sample and possibly the next few (depending on the width of TRC_DATA) are collected until a complete byte has been received. Bytes are transmitted least significant bit first, with TRC_DATA[0] representing the least significant bit in each beat of data. The receiver continues collecting bytes until a complete message has been received. The criteria for this depends on the trace format. After the last byte of a message, the data signals may then go to their idle state or a new message may begin in the next trace clock edge.
 
@@ -1412,7 +1415,7 @@ This example shows 8-bit parallel mode with `trPibClkCenter` = 0 transmitting a 
 image:./RISC-V-Trace-Control-Interface-images/pib-ref0.png[image]
 
 <<<
-And an example showing 8-bit parallel mode transmitting a 4-byte packet with `trPibClkCenter` = 1  
+And an example showing 8-bit parallel mode transmitting a 4-byte packet with `trPibClkCenter` = 1
 
 image:./RISC-V-Trace-Control-Interface-images/pib-ref1.png[image]
 
@@ -1440,7 +1443,7 @@ image:./RISC-V-Trace-Control-Interface-images/swt-uart.jpg[image]
 
 === Calibration Mode
 
-In optional calibration mode, the PIB transmits a repeating pattern. Probes can use this to automatically tune input delays due to skew on different PIB signal lines and to adjust to the transmitter's data rate (`trPibDivider` and `trPibClkCenter`). Calibration patterns for each mode are listed below. 
+In optional calibration mode, the PIB transmits a repeating pattern. Probes can use this to automatically tune input delays due to skew on different PIB signal lines and to adjust to the transmitter's data rate (`trPibDivider` and `trPibClkCenter`). Calibration patterns for each mode are listed below.
 
 .*PIB Calibration Patterns*
 [cols="25%,30%,~",options="header",align=center,width=80%]
@@ -1492,7 +1495,7 @@ Details should be defined the specification of each trace protocol.
 
 An implementation determines the data widths of the connection from the Trace Encoder or Trace Funnel and of the ATB port.
 
-ATB Bridge may optionally insert ATB alignment synchronization packets (controlled by `trAtbBridgeAsyncFreq` field) allowing trace decoding software to detect ATB packet boundaries. Not all protocols may require it. 
+ATB Bridge may optionally insert ATB alignment synchronization packets (controlled by `trAtbBridgeAsyncFreq` field) allowing trace decoding software to detect ATB packet boundaries. Not all protocols may require it.
 
 == Additional Material
 
@@ -1526,7 +1529,7 @@ These requirements are applicable to the entire trace sub-system.
 
 SRAM mode only:
 
-* Bit `trRamHasSRAM` must be tied to 1 and `trRamMode` must be tied to 0. 
+* Bit `trRamHasSRAM` must be tied to 1 and `trRamMode` must be tied to 0.
 * Bit `trRamWrap` must be implemented.
 * Register `trRamLimitLow` must be implemented but can be hard coded to value '2^M-4' (address 0x..FC).
 * Register `trRamWPLow` must at least accept a write of 0.
@@ -1549,7 +1552,7 @@ SMEM mode only:
 It is hard to define required mode as it depends on SoC bandwidth requirements and capabilities, but some general guidance may be provided.
 
 * 4-bit mode is supported by most (if not all) trace probes and less expensive MIPI20 connectors can be used.
-** 1-bit and 2-bit modes should be only used when there are critical constraints on the number of MCU pins. Not all trace probes may support these modes. 
+** 1-bit and 2-bit modes should be only used when there are critical constraints on the number of MCU pins. Not all trace probes may support these modes.
 * Serial mode should be only considered when either limited trace is required, or cores run slowly. Not all trace probes may support this mode and max allowed speeds may vary.
 ** Manchester encoding is self-synchronizing and may provide a more reliable trace. However UART mode may provide better bandwidth. It is suggested to support both.
 * 8-bit and 16-bit modes will provide better bandwidth, but require a more expensive Mictor connector and only more advanced trace probe models may support it.
@@ -1596,7 +1599,7 @@ Reset and Discovery should be performed as follows:
 * Reset the component by setting `tr??Active` = 0.
 ** This should be done by writing a value 0x0 to `tr??Control` register.
 * Read-back and wait until `tr??Active` = 0 is read, which means that a component reached a reset state.
-* Release a component from reset by setting `tr??Active` = 1. 
+* Release a component from reset by setting `tr??Active` = 1.
 ** This should be done by writing a value 0x1 to `tr??Control` register. This write will reset most of other enable/mode bits in this register and all WARL and read-only fields will be set to defaults.
 * Read-back and wait until `tr??Active` = 1 is read, which means that a component was released from reset.
 ** In this moment `tr??Enable` is set to 0 and the component is not yet enabled.
@@ -1661,7 +1664,7 @@ Enabling should work as follows:
 * Either manually set `trTeInstTracing=1` and/or `trTeDataTracing=1` bits or set triggers to start the trace.
 * Start hart[s] to be traced (hart could be already running as well - in this case trace will be generated in the moment when `trTeInstTracing` or `trTeDataTracing` bit is set).
 * Periodically read `trTeControl` for status of trace (as it may stop by itself due to triggers).
-** If RAM Sink was configured with `trRamStopOnWrap` = 1, read `trRamEnable` to see if RAM capture was stopped. 
+** If RAM Sink was configured with `trRamStopOnWrap` = 1, read `trRamEnable` to see if RAM capture was stopped.
 
 NOTE: Discovery may not be necessary to enable and test the trace during development of SoC. However, a discovery must be possible and should be tested by SoC designer - this is necessary for trace tools to work with that SoC without any customization.
 
@@ -1702,4 +1705,3 @@ Original donation from SiFive (which describes implementation of pre-ratified/in
 https://lists.riscv.org/g/tech-nexus/files/RISC-V-Trace-Control-Interface-Proposed-20200612.pdf[RISC-V-Trace-Control-Interface-Proposed-20200612.pdf]
 
 IMPORTANT: Not all trace tools may support pre-ratified/initial version 0. But all such tools should reject a version 0 with a very clear message.
-


### PR DESCRIPTION
Adds the new trTeDisSelfHosted bit for reserving the TE for debugger use.  Part of the self-hosted trace suite of extensions, so should not be merged until self-hosted trace (Smstrc*/Ssstrc*) is ratified.