### PR TITLE
Update GitHub Actions to requested versions

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     # Step 1: Checkout the repository
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: 'recursive'
 
@@ -40,21 +40,21 @@ jobs:
 
     # Step 4: Upload the built PDF files as independent artifacts
     - name: Upload RISC-V-Trace-Control-Interface PDF
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: RISC-V-Trace-Control-Interface
         path: ${{ github.workspace }}/docs/RISC-V-Trace-Control-Interface.pdf
         retention-days: 30
 
     - name: Upload RISC-V-Trace-Connectors PDF
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: RISC-V-Trace-Connectors
         path: ${{ github.workspace }}/docs/RISC-V-Trace-Connectors.pdf
         retention-days: 30
 
     - name: Upload RISC-V-N-Trace PDF
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: RISC-V-N-Trace
         path: ${{ github.workspace }}/docs/RISC-V-N-Trace.pdf
@@ -66,7 +66,7 @@ jobs:
       
     # Step 5:Create Release
     - name: Create Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         files: ${{ github.workspace }}/docs/*.pdf
         tag_name: v${{ env.SHORT_SHA }}


### PR DESCRIPTION
This updates GitHub Actions workflow references to the requested versions.

Targets:
- `actions/checkout` -> `v6`
- `actions/upload-artifact` -> `v6`
- `softprops/action-gh-release` -> `v2`
